### PR TITLE
Small fix on Fuel gauge.

### DIFF
--- a/Models/Flightdeck/Instruments/fuel/fuel-qty1.xml
+++ b/Models/Flightdeck/Instruments/fuel/fuel-qty1.xml
@@ -96,8 +96,8 @@ Syd Adams
         <factor>0.0755</factor>
         <axis>
             <x>0</x>
-            <y>-1</y>
-            <z>0</z>
+            <y>0</y>
+            <z>-1</z>
         </axis>
     </animation>
 


### PR DESCRIPTION
See picture:
![fuelgauge](https://cloud.githubusercontent.com/assets/12293276/11374049/6a852024-92d4-11e5-8c5e-821a58626eb4.JPG)

Right instrument shows now **AFT**
